### PR TITLE
feat: implement lightbox viewer for hero image

### DIFF
--- a/src/assets/images/icons/close.svg
+++ b/src/assets/images/icons/close.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="32"
+  height="32"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="white"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="18" y1="6" x2="6" y2="18" />
+  <line x1="6" y1="6" x2="18" y2="18" />
+</svg>

--- a/src/assets/images/icons/expand.svg
+++ b/src/assets/images/icons/expand.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="20"
+  height="20"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="white"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15 3h6v6" />
+  <path d="M9 21H3v-6" />
+  <path d="M21 3l-7 7" />
+  <path d="M3 21l7-7" />
+</svg>

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,95 @@
+import type React from "react";
+import { useState, useRef, useEffect } from "react";
+import closeIcon from "../assets/images/icons/close.svg";
+
+interface Props {
+  imageSrc: string;
+  alt: string;
+  caption?: string;
+  children: React.ReactNode;
+  className?: string;
+  "aria-label"?: string;
+}
+
+export const ImageLightbox: React.FC<Props> = ({
+  imageSrc,
+  alt,
+  caption,
+  children,
+  className = "contents cursor-pointer",
+  "aria-label": ariaLabel,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isOpen) {
+      dialog.showModal();
+    } else {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={className}
+        aria-label={ariaLabel}
+      >
+        {children}
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        onClose={handleClose}
+        className="p-0 bg-transparent border-none backdrop:bg-black/80 backdrop:backdrop-blur-sm open:flex open:items-center open:justify-center w-full h-full max-w-full max-h-full fixed inset-0"
+      >
+        {/* Backdrop to close the dialog */}
+        <button
+          type="button"
+          className="fixed inset-0 w-full h-full cursor-default"
+          onClick={handleClose}
+          aria-label="Close lightbox"
+        />
+
+        <div className="relative flex items-center justify-center w-full h-full p-4 pointer-events-none">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="fixed top-4 right-4 text-white hover:text-gray-300 z-50 cursor-pointer pointer-events-auto"
+            aria-label="Close"
+          >
+            <img src={closeIcon.src} width="32" height="32" alt="" />
+          </button>
+
+          <div className="max-w-[90vw] max-h-[90vh] flex flex-col items-center pointer-events-auto">
+            <img
+              src={imageSrc}
+              alt={alt}
+              className="w-full h-full object-contain shadow-2xl"
+            />
+            {caption && (
+              <p className="text-white mt-4 text-center text-sm md:text-base bg-black/40 px-4 py-2 rounded-lg backdrop-blur-sm select-none">
+                {caption}
+              </p>
+            )}
+          </div>
+        </div>
+      </dialog>
+      <style>{`
+        body:has(dialog[open]) {
+          overflow: hidden;
+        }
+      `}</style>
+    </>
+  );
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,9 @@
 import { Image } from "astro:assets";
 import Layout from "../layouts/Layout.astro";
 import LinkCard from "../components/LinkCard.astro";
+import { ImageLightbox } from "../components/ImageLightbox";
 import heroImage from "../assets/images/hero.png";
+import expandIcon from "../assets/images/icons/expand.svg";
 
 const links = [
   {
@@ -52,6 +54,16 @@ const links = [
     </div>
 
     <div class="w-[70%] h-full relative overflow-hidden right-area">
+      <ImageLightbox
+        client:load
+        imageSrc={heroImage.src}
+        alt="Hero Image"
+        caption="This photo of Tokyo Station was taken by me and processed using generative AI."
+        className="absolute top-4 right-4 z-20 p-2 bg-black/50 hover:bg-black/70 text-white rounded-full transition-colors cursor-pointer"
+        aria-label="Zoom image"
+      >
+        <img src={expandIcon.src} width="20" height="20" alt="" />
+      </ImageLightbox>
       <Image
         src={heroImage}
         alt=""


### PR DESCRIPTION
## Summary

Introduces a lightbox functionality to the hero section, allowing users to view the hero image at original size.

## Context

The hero image is a core visual asset, but current layout constraints limit its visibility. To improve the user experience without cluttering the primary UI, we've added an optional expanded view via a lightbox.

## Key Changes

- Added a "zoom-in" icon overlay on the hero image that triggers the viewer
- Implemented a lightweight modal to display the image in full-screen mode

## Verification Results

### Screenshots

<img width="1903" height="951" alt="image" src="https://github.com/user-attachments/assets/f513642b-2da1-4d9b-a007-44dfd457582f" />
