### PR TITLE
Add `check-dist-hash` action and integrate into workflows

### DIFF
--- a/.github/actions/check-dist-manifest/README.md
+++ b/.github/actions/check-dist-manifest/README.md
@@ -1,0 +1,36 @@
+# Check Dist Hash
+
+A GitHub Composite Action that calculates the SHA256 hash of the `dist` directory (currently hardcoded) and compares it with the previous build to determine if changes exist.
+
+## How it Works
+
+1. Generates a manifest file (`.candidate.manifest`) containing SHA256 hashes for all files in the `dist` directory.
+2. Restores the previous manifest (`.live.manifest`) from GitHub Actions cache.
+3. Compares the current manifest with the cached one.
+4. Sets the `is-dirty` output to `true` if changes are detected.
+
+## Interface
+
+### Inputs
+
+| Name           | Description                                                     | Default | Required |
+| :------------- | :-------------------------------------------------------------- | :------ | :------- |
+| `update-cache` | Whether to update the cached manifest when changes are detected | `false` | No       |
+
+### Outputs
+
+| Name       | Description                                                                                            |
+| :--------- | :----------------------------------------------------------------------------------------------------- |
+| `is-dirty` | Boolean string indicating if the `dist` directory differs from the cached manifest (`true` or `false`) |
+
+## Usage
+
+```yaml
+- name: Check hash
+  id: check_hash
+  uses: ./.github/actions/check-dist-hash
+
+- name: Conditional Execution
+  if: steps.check_hash.outputs.is-dirty == 'true'
+  run: echo "Changes detected. Proceeding..."
+```

--- a/.github/actions/check-dist-manifest/action.yaml
+++ b/.github/actions/check-dist-manifest/action.yaml
@@ -1,0 +1,59 @@
+name: "Check dist manifest"
+description: "Checks whether the dist directory differs from the cached manifest"
+inputs:
+  update-cache:
+    description: "Update the cached manifest when the dist directory has changed"
+    required: false
+    default: "false"
+outputs:
+  is-dirty:
+    description: "True when the dist directory differs from the cached manifest"
+    value: ${{ steps.compare.outputs.is-dirty }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate current manifest
+      shell: bash
+      run: |
+        if [ ! -d dist ]; then
+          echo "Error: dist/ directory not found."
+          exit 1
+        fi
+        find dist -type f -print0 | sort -z | xargs -0 sha256sum > .candidate.manifest
+
+    - name: Restore cached manifest
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: cache
+      with:
+        path: .live.manifest
+        key: dist-manifest-${{ github.run_id }}
+        restore-keys: |
+          dist-manifest-
+
+    - name: Compare manifests
+      id: compare
+      shell: bash
+      run: |
+        if [ ! -f .live.manifest ]; then
+          echo "No cached manifest found. Marking dist/ as changed."
+          echo "is-dirty=true" >> "$GITHUB_OUTPUT"
+        elif ! cmp -s .live.manifest .candidate.manifest; then
+          echo "dist/ has changed."
+          echo "is-dirty=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "dist/ is unchanged."
+          echo "is-dirty=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Update cached manifest
+      if: inputs.update-cache == 'true' && steps.compare.outputs.is-dirty == 'true'
+      shell: bash
+      run: mv -f .candidate.manifest .live.manifest
+
+    - name: Save cached manifest
+      if: inputs.update-cache == 'true' && steps.compare.outputs.is-dirty == 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: .live.manifest
+        key: dist-manifest-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
@@ -24,3 +26,10 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: pnpm lint && pnpm fmt
+      - name: Check hash
+        id: check_hash
+        uses: ./.github/actions/check-dist-hash
+      - name: Comment on PR if no changes
+        if: github.event_name == 'pull_request' && steps.check_hash.outputs.is-dirty == 'false'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body ":fast_forward: Merging this PR will have no impact on the live site as the build output remains unchanged."

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-slim
+    outputs:
+      skip-deploy: ${{ steps.check_hash.outputs.is-dirty == 'false' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build and upload artifacts
@@ -16,9 +18,13 @@ jobs:
         with:
           node-version: 24
           package-manager: pnpm@10
+      - name: Check hash
+        id: check_hash
+        uses: ./.github/actions/check-dist-hash
 
   deploy:
     needs: build
+    if: needs.build.outputs.skip-deploy == 'false'
     runs-on: ubuntu-slim
     permissions:
       # ref: https://github.com/actions/deploy-pages#security-considerations


### PR DESCRIPTION
## Summary

- Introduced the `check-dist-hash` composite GitHub Action.
- Integrated the action into existing workflows to ensure consistency in distribution artifacts.
