### PR TITLE
Update workflow to use `check-dist-manifest` instead of `check-dist-hash`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: pnpm lint && pnpm fmt
       - name: Check hash
         id: check_hash
-        uses: ./.github/actions/check-dist-hash
+        uses: ./.github/actions/check-dist-manifest
       - name: Comment on PR if no changes
         if: github.event_name == 'pull_request' && steps.check_hash.outputs.is-dirty == 'false'
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
           package-manager: pnpm@10
       - name: Check hash
         id: check_hash
-        uses: ./.github/actions/check-dist-hash
+        uses: ./.github/actions/check-dist-manifest
 
   deploy:
     needs: build


### PR DESCRIPTION
This pull request updates the workflow configuration to replace the `check-dist-hash` step with the more accurate and relevant `check-dist-manifest` step.

