### PR TITLE
(fix) update cache deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,8 @@ jobs:
       - name: Check hash
         id: check_hash
         uses: ./.github/actions/check-dist-manifest
+        with:
+          update-cache: true
 
   deploy:
     needs: build


### PR DESCRIPTION
When `dist` directory (build artifact) is updated or previous cache does not find, update dist-manifest (SHA256 hash list) to GitHub Actions cache.

ref: #433