### PR TITLE
(chore) Rename `check_hash` to `check-hash` in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,9 @@ jobs:
       - run: pnpm build
       - run: pnpm lint && pnpm fmt
       - name: Check hash
-        id: check_hash
+        id: check-hash
         uses: ./.github/actions/check-dist-manifest
       - name: Comment on PR if no changes
-        if: github.event_name == 'pull_request' && steps.check_hash.outputs.is-dirty == 'false'
+        if: github.event_name == 'pull_request' && steps.check-hash.outputs.is-dirty == 'false'
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body ":fast_forward: Merging this PR will have no impact on the live site as the build output remains unchanged."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,5 +31,8 @@ jobs:
         uses: ./.github/actions/check-dist-manifest
       - name: Comment on PR if no changes
         if: github.event_name == 'pull_request' && steps.check-hash.outputs.is-dirty == 'false'
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body ":fast_forward: Merging this PR will have no impact on the live site as the build output remains unchanged."
+        run: >
+          gh pr comment ${{ github.event.pull_request.number }}
+          --body ":fast_forward: No changes detected. Merging this PR will skip deployment."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-slim
     outputs:
-      skip-deploy: ${{ steps.check_hash.outputs.is-dirty == 'false' }}
+      skip-deploy: ${{ steps.check-hash.outputs.is-dirty == 'false' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build and upload artifacts
@@ -19,7 +19,7 @@ jobs:
           node-version: 24
           package-manager: pnpm@10
       - name: Check hash
-        id: check_hash
+        id: check-hash
         uses: ./.github/actions/check-dist-manifest
         with:
           update-cache: true


### PR DESCRIPTION
This pull request updates the naming convention for `check_hash` in the workflows directory, renaming it to `check-hash`.
