### PR TITLE
feat: responsive layout

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,8 +26,12 @@ const links = [
 ---
 
 <Layout title="chaya2z - Profile">
-  <section class="flex w-400 h-225 overflow-hidden relative main-container">
-    <div class="w-[30%] p-15 px-10 relative flex flex-col z-10 left-area">
+  <section
+    class="flex w-400 h-225 overflow-hidden relative main-container max-2xl:w-full max-2xl:h-screen max-md:flex-col max-md:overflow-y-auto max-md:bg-midnight-bg"
+  >
+    <div
+      class="w-[30%] p-15 px-10 relative flex flex-col z-10 left-area max-2xl:w-120 max-2xl:shrink-0 max-md:w-full max-md:shrink max-md:p-8 max-md:px-6 max-md:z-20 max-md:bg-midnight-bg/60 max-md:backdrop-blur-lg max-md:min-h-screen"
+    >
       <div class="flex flex-col justify-center grow">
         <header class="mb-12.5 relative z-10 header-section">
           <span
@@ -62,7 +66,11 @@ const links = [
       </footer>
     </div>
 
-    <div class="w-[70%] h-full relative overflow-hidden right-area">
+    <div
+      class="w-[70%] h-full relative overflow-hidden right-area max-2xl:flex-1 max-md:fixed max-md:top-0 max-md:left-0 max-md:w-full max-md:h-full max-md:z-10"
+    >
+      <div class="absolute inset-0 bg-midnight-bg/40 z-10 hidden max-md:block">
+      </div>
       <ImageLightbox
         client:load
         imageSrc={heroImage.src}
@@ -76,7 +84,7 @@ const links = [
       <Image
         src={heroImage}
         alt=""
-        class="w-full h-full object-cover image-pixelated bg-image"
+        class="w-full h-full object-cover image-pixelated bg-image max-md:blur-[2px]"
       />
       <div class="rain-container" aria-hidden="true"></div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,8 @@
   --color-tokyo-night-bg: #16161e;
 
   --font-noto-sans: "Noto Sans JP", sans-serif;
+
+  --breakpoint-2xl: 1600px;
 }
 
 @utility image-pixelated {


### PR DESCRIPTION
## Summary

* Keep the original desktop layout (≥1600px) visually identical to before.
* Add responsive behavior for tablet/mobile while prioritizing the left links section.
* Ensure the left column stays readable: fixed to 480px (<1600px), stack on mobile.

## Changes

* Tailwind theme
  * Define a custom 2xl breakpoint at 1600px to safely isolate desktop (≥1600px) from responsive rules.
* Home page layout (src/pages/index.astro)
  * Fix the left links column to 480px (400px content + 40px padding on both sides) for widths <1600px; prevent unwanted stretching/shrinking.
  * Keep desktop (1600×900) unchanged: no blur/overlay/effects at ≥1600px.
  * For tablet (<1600px): keep two-column layout; let the right area flex-fill the remaining space.
  * For mobile (<768px): switch to vertical stack; use the hero image as a fixed background with a subtle dark overlay, and apply blur only on mobile.
  * Improve text legibility on mobile via a semi-transparent backdrop on the left area.

## Verification

Manual checks with Chrome DevTools:

* 1700×1000 (desktop): left 30% (matches previous 1600×900 design), no blur, overlay hidden, right area is relative.
* 1200×900 / 876×900 (tablet): left stays at 480px fixed, right fills the rest, no blur, overlay hidden.
* ~500×740 (mobile): container stacks vertically; right area becomes fixed background, image blur(2px) applied, dark overlay visible; text remains readable.
